### PR TITLE
Customization and Profile ID support

### DIFF
--- a/src/entity/Document.ts
+++ b/src/entity/Document.ts
@@ -11,6 +11,7 @@ import {
   DocumentId,
   DocumentTypes,
   DEFAULT_CUSTOMIZATION_ID,
+  DEFAULT_PROFILE_ID,
 } from '../interface/IDocument';
 import DateOnly from '../valueObject/DateOnly';
 import DocumentType from '../valueObject/DocumentType';
@@ -32,7 +33,14 @@ export default class Document extends Entity<IDocument, string, DocumentId> {
   protected _documentType: DocumentTypes;
 
   constructor(props: IDocument, id?: DocumentId) {
-    super({ customizationId: DEFAULT_CUSTOMIZATION_ID, ...props }, id);
+    super(
+      {
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
+        ...props,
+      },
+      id,
+    );
   }
 
   public static create(
@@ -92,6 +100,20 @@ export default class Document extends Entity<IDocument, string, DocumentId> {
    */
   set customizationId(value: string) {
     this.props.customizationId = value;
+  }
+
+  /**
+   * Get the business process.
+   */
+  get businessProcess() {
+    return this.props.businessProcess;
+  }
+
+  /**
+   * Set the business process.
+   */
+  set businessProcess(value: string | undefined) {
+    this.props.businessProcess = value;
   }
 
   /**

--- a/src/entity/Document.ts
+++ b/src/entity/Document.ts
@@ -6,7 +6,12 @@
  * @licence MIT https://opensource.org/licenses/MIT
  */
 import { Entity } from '../base/Entity';
-import { IDocument, DocumentId, DocumentTypes } from '../interface/IDocument';
+import {
+  IDocument,
+  DocumentId,
+  DocumentTypes,
+  DEFAULT_CUSTOMIZATION_ID,
+} from '../interface/IDocument';
 import DateOnly from '../valueObject/DateOnly';
 import DocumentType from '../valueObject/DocumentType';
 import CurrencyCode from '../valueObject/CurrencyCode';
@@ -25,6 +30,10 @@ import Identifier from '../valueObject/Identifier';
 export default class Document extends Entity<IDocument, string, DocumentId> {
   protected _ruleset: AbstractRuleset;
   protected _documentType: DocumentTypes;
+
+  constructor(props: IDocument, id?: DocumentId) {
+    super({ customizationId: DEFAULT_CUSTOMIZATION_ID, ...props }, id);
+  }
 
   public static create(
     type: DocumentTypes,
@@ -69,6 +78,20 @@ export default class Document extends Entity<IDocument, string, DocumentId> {
    */
   set id(value: DocumentId) {
     this.props.id = value;
+  }
+
+  /**
+   * Get the customization ID.
+   */
+  get customizationId() {
+    return this.props.customizationId;
+  }
+
+  /**
+   * Set the customization ID.
+   */
+  set customizationId(value: string) {
+    this.props.customizationId = value;
   }
 
   /**

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -7,6 +7,9 @@ import UblWriter from './writers/UblWriter';
 const fixtureFiles = [
   'bis3_invoice_negativ.xml',
   'bis3_invoice_positive.xml',
+  'guide-example1.xml',
+  'guide-example2.xml',
+  'guide-example3.xml',
   'peppol-allowance.xml',
   'peppol-base.xml',
   'peppol-vat-o.xml',
@@ -14,9 +17,6 @@ const fixtureFiles = [
 
   // TODO: Fix these tests
   // 'ft_g2g_td01_con_allegato_bonifico_e_split_payment.xml',
-  // 'guide-example1.xml',
-  // 'guide-example2.xml',
-  // 'guide-example3.xml',
   // 'peppol-credit-note.xml',
   // 'peppol-rounding.xml',
   // 'ubl-invoice-2.0-example.xml',

--- a/src/interface/IDocument.ts
+++ b/src/interface/IDocument.ts
@@ -32,9 +32,12 @@ export enum DocumentTypes {
 export const DEFAULT_CUSTOMIZATION_ID =
   'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0';
 
+export const DEFAULT_PROFILE_ID = 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0';
+
 export interface IDocument {
   id: DocumentId;
   customizationId?: string;
+  businessProcess?: string;
   issueDate?: DateOnly;
   dueDate?: DateOnly;
   type?: DocumentType;

--- a/src/interface/IDocument.ts
+++ b/src/interface/IDocument.ts
@@ -29,8 +29,12 @@ export enum DocumentTypes {
   CreditNote = 'credit_note',
 }
 
+export const DEFAULT_CUSTOMIZATION_ID =
+  'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0';
+
 export interface IDocument {
   id: DocumentId;
+  customizationId?: string;
   issueDate?: DateOnly;
   dueDate?: DateOnly;
   type?: DocumentType;

--- a/src/readers/UblReader.spec.ts
+++ b/src/readers/UblReader.spec.ts
@@ -1,5 +1,5 @@
 import UblReader from './UblReader';
-import { DocumentId } from '../interface/IDocument';
+import { DEFAULT_CUSTOMIZATION_ID, DocumentId } from '../interface/IDocument';
 import DateOnly from '../valueObject/DateOnly';
 import DocumentType from '../valueObject/DocumentType';
 import CurrencyCode from '../valueObject/CurrencyCode';
@@ -50,6 +50,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('12345'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         dueDate: DateOnly.create('2019-02-24'),
         issueDate: DateOnly.create('2019-01-25'),
         periodStart: DateOnly.create('2018-09-01'),
@@ -162,6 +163,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('12345'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         dueDate: DateOnly.create('2019-02-24'),
         issueDate: DateOnly.create('2019-01-25'),
         periodStart: DateOnly.create('2018-09-01'),
@@ -282,6 +284,7 @@ describe('UblReader', () => {
       expect(result.toPrimitive()).toEqual({
         attachments: [expect.any(Attachment)],
         id: new DocumentId('1316/85'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         issueDate: DateOnly.create('2020-02-13'),
         type: DocumentType.create('380'),
         payment: Payment.create({
@@ -386,6 +389,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('12115118'),
+        customizationId: 'urn:cen.eu:en16931:2017',
         issueDate: DateOnly.create('2015-01-09'),
         dueDate: DateOnly.create('2015-01-09'),
         type: DocumentType.create('380'),
@@ -678,6 +682,7 @@ describe('UblReader', () => {
           }),
         ],
         id: new DocumentId('TOSL108'),
+        customizationId: 'urn:cen.eu:en16931:2017',
         issueDate: DateOnly.create('2013-06-30'),
         dueDate: DateOnly.create('2013-07-20'),
         taxPointDate: DateOnly.create('2013-06-30'),
@@ -956,6 +961,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('TOSL108'),
+        customizationId: 'urn:cen.eu:en16931:2017',
         issueDate: DateOnly.create('2013-04-10'),
         dueDate: DateOnly.create('2013-05-10'),
         periodStart: DateOnly.create('2013-01-01'),
@@ -1060,6 +1066,8 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('A00095678'),
+        customizationId:
+          'urn:oasis:names:specification:ubl:xpath:Invoice-2.0:sbs-1.0-draft',
         issueDate: DateOnly.create('2005-06-21'),
         dueDate: DateOnly.create('2005-07-21'),
         taxPointDate: DateOnly.create('2005-06-21'),
@@ -1186,6 +1194,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('Snippet1'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         dueDate: DateOnly.create('2017-12-01'),
         issueDate: DateOnly.create('2017-11-13'),
         taxPointDate: DateOnly.create('2017-12-01'),
@@ -1422,6 +1431,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('Snippet1'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         dueDate: DateOnly.create('2017-12-01'),
         issueDate: DateOnly.create('2017-11-13'),
         precedingInvoiceReference: [
@@ -1608,6 +1618,7 @@ describe('UblReader', () => {
       expect(result.validate()).toEqual({ errors: [], warning: [] });
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('Snippet1'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         dueDate: DateOnly.create('2017-12-02'),
         issueDate: DateOnly.create('2017-11-13'),
         precedingInvoiceReference: [
@@ -1782,6 +1793,7 @@ describe('UblReader', () => {
         currency: CurrencyCode.create('EUR'),
         dueDate: DateOnly.create('2022-11-11'),
         id: new DocumentId('SampleForDecimals'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         issueDate: DateOnly.create('2022-11-03'),
         lines: [
           DocumentLine.create({
@@ -1856,6 +1868,7 @@ describe('UblReader', () => {
         buyerReference: 'test reference',
         currency: CurrencyCode.create('SEK'),
         id: new DocumentId('Vat-O'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         issueDate: DateOnly.create('2018-08-30'),
         lines: [
           DocumentLine.create({
@@ -1981,6 +1994,7 @@ describe('UblReader', () => {
         }),
         dueDate: DateOnly.create('2017-12-01'),
         id: new DocumentId('Snippet1'),
+        customizationId: DEFAULT_CUSTOMIZATION_ID,
         issueDate: DateOnly.create('2017-11-13'),
         lines: [
           DocumentLine.create({

--- a/src/readers/UblReader.spec.ts
+++ b/src/readers/UblReader.spec.ts
@@ -1,5 +1,9 @@
 import UblReader from './UblReader';
-import { DEFAULT_CUSTOMIZATION_ID, DocumentId } from '../interface/IDocument';
+import {
+  DEFAULT_CUSTOMIZATION_ID,
+  DEFAULT_PROFILE_ID,
+  DocumentId,
+} from '../interface/IDocument';
 import DateOnly from '../valueObject/DateOnly';
 import DocumentType from '../valueObject/DocumentType';
 import CurrencyCode from '../valueObject/CurrencyCode';
@@ -51,6 +55,7 @@ describe('UblReader', () => {
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('12345'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         dueDate: DateOnly.create('2019-02-24'),
         issueDate: DateOnly.create('2019-01-25'),
         periodStart: DateOnly.create('2018-09-01'),
@@ -164,6 +169,7 @@ describe('UblReader', () => {
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('12345'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         dueDate: DateOnly.create('2019-02-24'),
         issueDate: DateOnly.create('2019-01-25'),
         periodStart: DateOnly.create('2018-09-01'),
@@ -285,6 +291,7 @@ describe('UblReader', () => {
         attachments: [expect.any(Attachment)],
         id: new DocumentId('1316/85'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         issueDate: DateOnly.create('2020-02-13'),
         type: DocumentType.create('380'),
         payment: Payment.create({
@@ -683,6 +690,7 @@ describe('UblReader', () => {
         ],
         id: new DocumentId('TOSL108'),
         customizationId: 'urn:cen.eu:en16931:2017',
+        businessProcess: 'Invoicing on purchase order',
         issueDate: DateOnly.create('2013-06-30'),
         dueDate: DateOnly.create('2013-07-20'),
         taxPointDate: DateOnly.create('2013-06-30'),
@@ -1068,6 +1076,8 @@ describe('UblReader', () => {
         id: new DocumentId('A00095678'),
         customizationId:
           'urn:oasis:names:specification:ubl:xpath:Invoice-2.0:sbs-1.0-draft',
+        businessProcess:
+          'bpid:urn:oasis:names:draft:bpss:ubl-2-sbs-invoice-notification-draft',
         issueDate: DateOnly.create('2005-06-21'),
         dueDate: DateOnly.create('2005-07-21'),
         taxPointDate: DateOnly.create('2005-06-21'),
@@ -1195,6 +1205,7 @@ describe('UblReader', () => {
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('Snippet1'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         dueDate: DateOnly.create('2017-12-01'),
         issueDate: DateOnly.create('2017-11-13'),
         taxPointDate: DateOnly.create('2017-12-01'),
@@ -1432,6 +1443,7 @@ describe('UblReader', () => {
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('Snippet1'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         dueDate: DateOnly.create('2017-12-01'),
         issueDate: DateOnly.create('2017-11-13'),
         precedingInvoiceReference: [
@@ -1619,6 +1631,7 @@ describe('UblReader', () => {
       expect(result.toPrimitive()).toEqual({
         id: new DocumentId('Snippet1'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         dueDate: DateOnly.create('2017-12-02'),
         issueDate: DateOnly.create('2017-11-13'),
         precedingInvoiceReference: [
@@ -1794,6 +1807,7 @@ describe('UblReader', () => {
         dueDate: DateOnly.create('2022-11-11'),
         id: new DocumentId('SampleForDecimals'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         issueDate: DateOnly.create('2022-11-03'),
         lines: [
           DocumentLine.create({
@@ -1869,6 +1883,7 @@ describe('UblReader', () => {
         currency: CurrencyCode.create('SEK'),
         id: new DocumentId('Vat-O'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         issueDate: DateOnly.create('2018-08-30'),
         lines: [
           DocumentLine.create({
@@ -1995,6 +2010,7 @@ describe('UblReader', () => {
         dueDate: DateOnly.create('2017-12-01'),
         id: new DocumentId('Snippet1'),
         customizationId: DEFAULT_CUSTOMIZATION_ID,
+        businessProcess: DEFAULT_PROFILE_ID,
         issueDate: DateOnly.create('2017-11-13'),
         lines: [
           DocumentLine.create({

--- a/src/readers/UblReader.ts
+++ b/src/readers/UblReader.ts
@@ -122,12 +122,6 @@ export default class UblReader extends AbstractReader {
       }),
     );
 
-    // BT-23: Business process type
-    const businessProcess = documentNode['cbc:ProfileID'];
-    if (businessProcess) {
-      // console.info(businessProcess);
-    }
-
     // BT-9: Due date
     const dueDate =
       documentNode['cbc:DueDate'] ??
@@ -254,6 +248,9 @@ export default class UblReader extends AbstractReader {
 
       // BT-22: Notes
       notes: strOrUnd(documentNode['cbc:Note']),
+
+      // BT-23: Business process type
+      businessProcess: strOrUnd(documentNode['cbc:ProfileID']),
 
       // BT-24
       customizationId: strOrUnd(customizationId),

--- a/src/readers/UblReader.ts
+++ b/src/readers/UblReader.ts
@@ -255,6 +255,9 @@ export default class UblReader extends AbstractReader {
       // BT-22: Notes
       notes: strOrUnd(documentNode['cbc:Note']),
 
+      // BT-24
+      customizationId: strOrUnd(customizationId),
+
       // BG-3: Preceding invoice references
       precedingInvoiceReference: precedingInvoiceReference.length
         ? precedingInvoiceReference

--- a/src/writers/UblWriter.ts
+++ b/src/writers/UblWriter.ts
@@ -36,7 +36,7 @@ export default class UblWriter extends AbstractWriter {
       Invoice: {
         ...xmlNamespaces,
         'cbc:CustomizationID': document.customizationId,
-        'cbc:ProfileID': 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
+        'cbc:ProfileID': document.businessProcess,
         'cbc:ID': document.id.toPrimitive(),
         'cbc:IssueDate': document.issueDate?.toPrimitive(),
         'cbc:DueDate': document.dueDate?.toPrimitive(),

--- a/src/writers/UblWriter.ts
+++ b/src/writers/UblWriter.ts
@@ -35,8 +35,7 @@ export default class UblWriter extends AbstractWriter {
       '?xml': { attr_version: '1.0', attr_encoding: 'UTF-8' },
       Invoice: {
         ...xmlNamespaces,
-        'cbc:CustomizationID':
-          'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0',
+        'cbc:CustomizationID': document.customizationId,
         'cbc:ProfileID': 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0',
         'cbc:ID': document.id.toPrimitive(),
         'cbc:IssueDate': document.issueDate?.toPrimitive(),


### PR DESCRIPTION
Adds support for [BT-23](https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cbc-ProfileID/) and [BT-24](https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cbc-CustomizationID/). In both cases, there is a standard default value. As these properties are now supported, enabling more round trip tests as they are passing now.